### PR TITLE
Change all instances of 'serverity' to 'severity' (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Content-Type: application/json
     "messageContent": "{{ escape message }}",
     "messageTitle": "{{ title }}",
     "urlLogAccessable": "http://url-to-webserver/logs/",
-    "serverity": "{{ severity }}"
+    "severity": "{{ severity }}"
 }
 
 //Secrets:

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ type webhookRequest struct {
 	DiscordWebhook   string
 	MessageContent   string
 	UrlLogAccessable string
-	Serverity        string
+	Severity        string
 	Title            string
 }
 
@@ -63,15 +63,15 @@ func webhook(ctx echo.Context) error {
 		DiscordWebhook:   jsonBody["discordWebhook"].(string),
 		MessageContent:   jsonBody["messageContent"].(string),
 		UrlLogAccessable: jsonBody["urlLogAccessable"].(string),
-		Serverity:        jsonBody["serverity"].(string),
+		Severity:        jsonBody["severity"].(string),
 		Title:            jsonBody["messageTitle"].(string),
 	}
 
 	var embedColor string
 	var description string
 
-	// Embed colour based on Serverity
-	switch webhookrequest.Serverity {
+	// Embed colour based on Severity
+	switch webhookrequest.Severity {
 	case "info":
 		embedColor = "2123412"
 	case "notice":


### PR DESCRIPTION
I know it's just a typo, but I appreciate your work on this project and thought it worth correcting, both to align with the actual spelling and with the value of the same name being provided by PVE. Not sure if there is somewhere I missed where this should be set with a new maj ver because of the change in the parameter name anywhere, but happy to correct that if so; I've also left this open to edits if there's anything like that you'd like to do as well. 